### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ python:
 
 install:
   - pip install --upgrade pip
-  - pip install coveralls pytest pytest-cov -r requirements_ci.txt
+  - pip install codespell coveralls pytest pytest-cov -r requirements_ci.txt
 
 # command to run tests
 script:
-   pytest --cov=test/
+  - codespell --ignore-words-list="nd,te"
+  - pytest --cov=test/
 
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Users can consider using OpenCDA for <strong>initial algorithmic testing</strong
 The key features of OpenCDA are:
 * <strong>Integration</strong>: OpenCDA utilizes CARLA and SUMO separately, as well as integrates them together for realistic scene rendering, vehicle modeling, and traffic simulation.
 * <strong> Full-stack</strong> prototype CDA Platform in Simulation: OpenCDA provides a simple prototype automated driving and cooperative driving platform, all in Python, that contains perception, localization, planning, control, and V2X communication modules.
-* <strong>Modularity</strong>: OpenCDA is highly modularized, enabling users to conveniently replace any default algorithms or protocols with their own customzied design. 
+* <strong>Modularity</strong>: OpenCDA is highly modularized, enabling users to conveniently replace any default algorithms or protocols with their own customized design. 
 * <strong>Benchmark</strong>: OpenCDA offers benchmark testing scenarios, benchmark baseline maps, state-of-the-art benchmark algorithms for ADS and Cooperative ADS functions, and benchmark evaluation metrics.
 * <strong>Connectivity and Cooperation</strong>: OpenCDA supports various levels and categories of cooperation between CAVs in simulation. This differentiates OpenCDA from other single vehicle simulation tools.
 
@@ -85,7 +85,7 @@ The current version features the following:
 ## In Future Releases
 Future versions are expected to include the following:
 * OpenCDA v0.2.0 and above software stack, including signalized intersection and corridor applications, cooperative perception and localization, enhanced scenario generation/manager and scenario database for newly added CDA applications)
-* SUMO only simulation which includes SUMO impplementation of all cooperative driving applications using behavior based approach (consistent with CARLA implementation)
+* SUMO only simulation which includes SUMO implementation of all cooperative driving applications using behavior based approach (consistent with CARLA implementation)
 * Software-in-the-loop interfaces with two open-source ADS platforms, i.e., Autoware and CARMA
 * hardware-in-the-loop interfaces and example projects with a real automated driving vehicle platform and a driving simulator
 

--- a/docs/md_files/codebase_structure.md
+++ b/docs/md_files/codebase_structure.md
@@ -13,7 +13,7 @@ OpenCDA
 │   │   ├── application # implementation of cooperative driving applications
 │   │   ├── common # base class and communication class for cavs
 │   │   ├── plan # planning algorithms
-│   │   └── sensing # perception adn localization algorithms.
+│   │   └── sensing # perception and localization algorithms.
 │   ├── customize # where the users put their customized algorithm to replace the default modules
 │   ├── scenario_testing # where all scenario testing scripts and yaml files exist
 │   │   └── config_yaml # the yaml file defining the testing scenarios

--- a/docs/md_files/developer_tutorial.md
+++ b/docs/md_files/developer_tutorial.md
@@ -43,7 +43,7 @@ def run_scenario(opt, config_yaml):
         for platoon in platoon_list:
             platoon.update_information()
             platoon.run_step()
-        # update signle CAV
+        # update single CAV
         for i, single_cav in enumerate(single_cav_list):
             # If the CAV is merged into one of the platoon, then we should let platoon manage it.
             # Thus we should remove them from single_cav_list
@@ -205,7 +205,7 @@ Now we will introduce each of them:
         return tm, bg_list
     ```
 
-    The `spawn_vehicles_by_list` has similar structure as `create_vehicle_manager` with the support of randomness of the vehicles' apperance and colors. Notice that, different from CAVs, we will set autopilot to `True` for those background traffic and we will return a list of `carla.Vehicle` instead of the `VehicleManager`  used in the `Create_vehicle_manager`. 
+    The `spawn_vehicles_by_list` has similar structure as `create_vehicle_manager` with the support of randomness of the vehicles' appearance and colors. Notice that, different from CAVs, we will set autopilot to `True` for those background traffic and we will return a list of `carla.Vehicle` instead of the `VehicleManager`  used in the `Create_vehicle_manager`. 
 
 ### VehicleManager
 

--- a/docs/md_files/getstarted.md
+++ b/docs/md_files/getstarted.md
@@ -83,5 +83,5 @@ python opencda.py -t platoon_joining_2lanefree_cosim
 python opencda.py -t platoon_joining_town06_carla --apply_ml
 ```
 A single CAV will try to overtake several human-driven vehicles to join the platoon from the back.
-Pytorch is required for this test since we use yolov5 detetion.
+Pytorch is required for this test since we use yolov5 detection.
 ![](images/platoon_joining_town06.gif)

--- a/docs/md_files/introduction.md
+++ b/docs/md_files/introduction.md
@@ -30,7 +30,7 @@ OpenCDA is created to fill such gaps.
 The key features of OpenCDA are:
 * <strong>Integration</strong>: OpenCDA utilizes CARLA and SUMO separately, as well as integrates them together for realistic scene rendering, vehicle modeling, and traffic simulation.
 * <strong> Full-stack</strong> prototype CDA Platform in Simulation: OpenCDA provides a simple prototype automated driving and cooperative driving platform, all in Python, that contains perception, localization, planning, control, and V2X communication modules.
-* <strong>Modularity</strong>: OpenCDA is highly modularized, enabling users to conveniently replace any default algorithms or protocols with their own customzied design. 
+* <strong>Modularity</strong>: OpenCDA is highly modularized, enabling users to conveniently replace any default algorithms or protocols with their own customized design. 
 * <strong>Benchmark</strong>: OpenCDA offers benchmark testing scenarios, benchmark baseline maps, state-of-the-art benchmark algorithms for ADS and Cooperative ADS functions, and benchmark evaluation metrics.
 * <strong>Connectivity and Cooperation</strong>: OpenCDA supports various levels and categories of cooperation between CAVs in simulation. This differentiates OpenCDA from other single vehicle simulation tools.
 

--- a/docs/md_files/logic_flow.md
+++ b/docs/md_files/logic_flow.md
@@ -76,7 +76,7 @@ eval_manager = \
 
 ### Step2: Construct scenario (Co-Simulation)
 Constructing a scenario under co-simulation setting is very similar with building scenario 
-in CARLA only. There are only two differences: 1) Co-simulation requires addtional Sumo files. 2)
+in CARLA only. There are only two differences: 1) Co-simulation requires additional Sumo files. 2)
 Instead of using `ScenarioManager`, `CoScenarioManager` is used to control the traffic. Check
 [Traffic Generation under Sumo](traffic_generation.html#sumo-traffic-management-co-simulation) section to see more details.
 

--- a/docs/md_files/yaml_define.md
+++ b/docs/md_files/yaml_define.md
@@ -18,10 +18,10 @@ vehicle_base: &vehicle_base # define cav default parameters
   behavior: &base_behavior # define planning related parameters
   controller: &base_controller # define controller
     type: pid_controller # define the type of controller
-    args: ...  # define the detailed parmaters of the controller
+    args: ...  # define the detailed parameters of the controller
   v2x: &base_v2x # define v2x configuration
 
-carla_traffic_manager: # define the background traffic controled by carla.TrafficManager
+carla_traffic_manager: # define the background traffic controlled by carla.TrafficManager
   global_speed_perc: -100 # define the default speed of traffic flow
   auto_lane_change: false # whether lane change is allowed in the traffic flow
   ...: # some other parameters

--- a/docs/opencda.customize.core.sensing.localization.rst
+++ b/docs/opencda.customize.core.sensing.localization.rst
@@ -4,7 +4,7 @@ opencda.customize.core.sensing.localization package
 Submodules
 ----------
 
-opencda.customize.core.sensing.localization.extented\_kalman\_filter module
+opencda.customize.core.sensing.localization.extended\_kalman\_filter module
 ---------------------------------------------------------------------------
 
 .. automodule:: opencda.customize.core.sensing.localization.extented_kalman_filter

--- a/opencda/co_simulation/sumo_integration/bridge_helper.py
+++ b/opencda/co_simulation/sumo_integration/bridge_helper.py
@@ -29,7 +29,7 @@ from opencda.co_simulation.sumo_integration.sumo_simulation import SumoSignalSta
 
 class BridgeHelper(object):
     """
-    BridgeHelper provides methos to ease the co-simulation between sumo and carla.
+    BridgeHelper provides methods to ease the co-simulation between sumo and carla.
     """
 
     blueprint_library = []
@@ -319,7 +319,7 @@ class BridgeHelper(object):
                 bool(current_lights & SumoVehSignal.FOGLIGHT)):
             current_lights ^= SumoVehSignal.FOGLIGHT
 
-        # High beam ligth.
+        # High beam light.
         if (bool(carla_lights & carla.VehicleLightState.HighBeam) !=
                 bool(current_lights & SumoVehSignal.HIGHBEAM)):
             current_lights ^= SumoVehSignal.HIGHBEAM

--- a/opencda/co_simulation/sumo_integration/carla_simulation.py
+++ b/opencda/co_simulation/sumo_integration/carla_simulation.py
@@ -81,7 +81,7 @@ class CarlaSimulation(object):
         """
         Accessor for traffic light state.
 
-        If the traffic ligth does not exist, returns None.
+        If the traffic light does not exist, returns None.
         """
         if landmark_id not in self._tls:
             return None

--- a/opencda/co_simulation/sumo_integration/sumo_simulation.py
+++ b/opencda/co_simulation/sumo_integration/sumo_simulation.py
@@ -183,7 +183,7 @@ class SumoTLManager(object):
     @staticmethod
     def subscribe(tlid):
         """
-        Subscribe the given traffic ligth to the following variables:
+        Subscribe the given traffic light to the following variables:
 
             * Current program.
             * Current phase.
@@ -196,7 +196,7 @@ class SumoTLManager(object):
     @staticmethod
     def unsubscribe(tlid):
         """
-        Unsubscribe the given traffic ligth from receiving updated information each step.
+        Unsubscribe the given traffic light from receiving updated information each step.
         """
         traci.trafficlight.unsubscribe(tlid)
 
@@ -337,7 +337,7 @@ class SumoSimulation(object):
         # Creating a random route to be able to spawn carla actors.
         traci.route.add("carla_route", [traci.edge.getIDList()[0]])
 
-        # Variable to asign an id to new added actors.
+        # Variable to assign an id to new added actors.
         self._sequential_id = 0
 
         # Structures to keep track of the spawned and destroyed vehicles at each time step.
@@ -447,7 +447,7 @@ class SumoSimulation(object):
         """
         Accessor for traffic light state.
 
-        If the traffic ligth does not exist, returns None.
+        If the traffic light does not exist, returns None.
         """
         return self.traffic_light_manager.get_state(landmark_id)
 

--- a/opencda/core/actuation/control_manager.py
+++ b/opencda/core/actuation/control_manager.py
@@ -21,7 +21,7 @@ class ControlManager(object):
     Attributes
     ----------
     controller : opencda object.
-        The controller object of the OpenCDA framwork.
+        The controller object of the OpenCDA framework.
     """
 
     def __init__(self, control_config):

--- a/opencda/core/actuation/pid_controller.py
+++ b/opencda/core/actuation/pid_controller.py
@@ -191,7 +191,7 @@ class Controller:
         target_speed : float
             Target speed of the ego vehicle.
 
-        waypoint : carla.loaction
+        waypoint : carla.location
             Target location.
 
         Returns

--- a/opencda/core/application/platooning/fsm.py
+++ b/opencda/core/application/platooning/fsm.py
@@ -36,7 +36,7 @@ class FSM(Enum):
         vehicle will switch to maintaining state.
     LEADING_MODE : int
         The vehicle is the platoon leader.
-    ABONDON:
+    ABANDON:
         Current joining is abandoned.
     DISABLE:
         V2X is not available and thus won't join any platoon.
@@ -51,5 +51,5 @@ class FSM(Enum):
     FRONT_JOINING = 7
     JOINING_FINISHED = 8
     LEADING_MODE = 9
-    ABONDON = 10
+    ABANDON = 10
     DISABLE = 11

--- a/opencda/core/application/platooning/platoon_behavior_agent.py
+++ b/opencda/core/application/platooning/platoon_behavior_agent.py
@@ -181,7 +181,7 @@ class PlatooningBehaviorAgent(BehaviorAgent):
         if status == FSM.BACK_JOINING:
             target_speed, target_waypoint, new_status = \
                 self.run_step_back_joining()
-            # if joining is finshed
+            # if joining is finished
             if new_status == FSM.JOINING_FINISHED:
                 self.joining_finish_manager()
             return target_speed, target_waypoint
@@ -193,7 +193,7 @@ class PlatooningBehaviorAgent(BehaviorAgent):
             self.v2x_manager.set_platoon_status(new_status)
 
             # if joining abandoned
-            if new_status == FSM.ABONDON:
+            if new_status == FSM.ABANDON:
                 self.v2x_manager.set_platoon_status(FSM.SEARCHING)
                 _, rear_vehicle_manager = \
                     self.v2x_manager.get_platoon_front_rear()
@@ -881,7 +881,7 @@ class PlatooningBehaviorAgent(BehaviorAgent):
                 super().run_step(
                     self.max_speed -
                     self.speed_lim_dist),
-                FSM.ABONDON)
+                FSM.ABANDON)
 
         # if the ego vehilce is already behind the platooning
         if angle <= 90:

--- a/opencda/core/application/platooning/platooning_manager.py
+++ b/opencda/core/application/platooning/platooning_manager.py
@@ -35,7 +35,7 @@ class PlatooningManager(object):
     vehicle_manager_list : list
         A list of all vehciel managers within the platoon.
     destination : carla.location
-        The destiantion of the current plan.
+        The destination of the current plan.
     center_loc : carla.location
         The center location of the platoon.
     leader_target_speed : float
@@ -81,7 +81,7 @@ class PlatooningManager(object):
 
     def add_member(self, vehicle_manager, leader=False):
         """
-        Add memeber to the current platooning
+        Add member to the current platooning
 
         Parameters
         __________
@@ -196,7 +196,7 @@ class PlatooningManager(object):
 
     def set_destination(self, destination):
         """
-        Set desination of the vehicle managers in the platoon.
+        Set destination of the vehicle managers in the platoon.
         """
         self.destination = destination
         for i in range(len(self.vehicle_manager_list)):

--- a/opencda/core/common/data_dumper.py
+++ b/opencda/core/common/data_dumper.py
@@ -150,7 +150,7 @@ class DataDumper(object):
 
     def save_yaml_file(self, perception_manager, localization_manager):
         """
-        Save objects positions/spped, true ego position,
+        Save objects positions/speed, true ego position,
         predicted ego position, sensor transformations.
 
         Parameters

--- a/opencda/core/plan/behavior_agent.py
+++ b/opencda/core/plan/behavior_agent.py
@@ -353,7 +353,7 @@ class BehaviorAgent(object):
         WARNING: What follows is a proxy to avoid having a car brake after
         running a yellow light. This happens because the car is still under
         the influence of the semaphore, even after passing it.
-        So, the semaphore id is temporarely saved to ignore it and go around
+        So, the semaphore id is temporarily saved to ignore it and go around
         this issue, until the car is near a new one.
 
         Parameters
@@ -828,7 +828,7 @@ class BehaviorAgent(object):
                             self.overtake_counter > 0
                             or self.get_local_planner().potential_curved_road):
             car_following_flag = True
-        # 6. overtake handeling
+        # 6. overtake handling
         elif is_hazard and self.overtake_allowed and \
                 self.overtake_counter <= 0:
             obstacle_speed = get_speed(obstacle_vehicle)

--- a/opencda/core/plan/global_route_planner_dao.py
+++ b/opencda/core/plan/global_route_planner_dao.py
@@ -75,7 +75,7 @@ class GlobalRoutePlannerDAO(object):
         The method returns waypoint at given location.
 
         Args:
-            -location (carla.lcoation): Vehicle location.
+            -location (carla.location): Vehicle location.
         Returns:
             -waypoint (carla.waypoint): Newly generated waypoint close
             to location.

--- a/opencda/core/plan/local_planner_behavior.py
+++ b/opencda/core/plan/local_planner_behavior.py
@@ -43,7 +43,7 @@ class LocalPlanner(object):
     Parameters
     ----------
     agent : carla.agent
-        The carla.agent that applying vehicle contorl.
+        The carla.agent that applying vehicle control.
 
     carla_map : carla.map
         The HD map of the current simulation world.

--- a/opencda/core/plan/spline.py
+++ b/opencda/core/plan/spline.py
@@ -67,7 +67,7 @@ class Spline:
         Args:
             - t (float): if t is outside of the input x, return None
         Returns:
-            - result (float): The calcualtion result of position.
+            - result (float): The calculation result of position.
               If t is outside the range of x, return None.
 
         """
@@ -221,7 +221,7 @@ class Spline2D:
 
 def calc_spline_course(x, y, ds=0.1):
     """
-    Caculate 2D splice course.
+    Calculate 2D splice course.
 
     Args:
         -x (float): The x coordinate of the input point.
@@ -257,7 +257,7 @@ def main():
     import matplotlib.pyplot as plt
     x = [-135, -131, -131, -131]
     y = [6.43, 10.83, 100.38, 131]
-    ds = 0.1  # [m] distance of each intepolated points
+    ds = 0.1  # [m] distance of each interpolated points
 
     sp = Spline2D(x, y)
     s = np.arange(0, sp.s[-1], ds)

--- a/opencda/core/sensing/localization/coordinate_transform.py
+++ b/opencda/core/sensing/localization/coordinate_transform.py
@@ -10,7 +10,7 @@ import numpy as np
 def geo_to_transform(lat, lon, alt, lat_0, lon_0, alt_0):
     """
     Convert WG84 to ENU. The origin of the ENU should pass the geo reference.
-    Note this function is a writen by reversing the
+    Note this function is a written by reversing the
     official API transform_to_geo.
 
     Parameters

--- a/opencda/core/sensing/localization/localization_debug_helper.py
+++ b/opencda/core/sensing/localization/localization_debug_helper.py
@@ -174,7 +174,7 @@ class LocDebugHelper(object):
             -figures(matplotlib.pyplot.plot): The plot of
             localization related figures.
             -perform_txt(txt file): The localization related
-            datas saved as text file.
+            data saved as text file.
 
         """
         figure, axis = plt.subplots(3, 2)

--- a/opencda/core/sensing/perception/o3d_lidar_libs.py
+++ b/opencda/core/sensing/perception/o3d_lidar_libs.py
@@ -73,7 +73,7 @@ def o3d_pointcloud_encode(raw_data, point_cloud):
 
     # Isolate the 3D data
     points = raw_data[:, :-1]
-    # We're negating the y to correclty visualize a world that matches
+    # We're negating the y to correctly visualize a world that matches
     # what we see in Unreal since Open3D uses a right-handed coordinate system
     points[:, :1] = -points[:, :1]
 
@@ -242,10 +242,10 @@ def o3d_camera_lidar_fusion(objects,
 
         # get the eight corner of the bounding boxes.
         corner = np.asarray(aabb.get_box_points())
-        # covert back to unreal coordinate
+        # convert back to unreal coordinate
         corner[:, :1] = -corner[:, :1]
         corner = corner.transpose()
-        # extend (3, 8) to (4, 8) for homogenous transformation
+        # extend (3, 8) to (4, 8) for homogeneous transformation
         corner = np.r_[corner, [np.ones(corner.shape[1])]]
         # project to world reference
         corner = st.sensor_to_world(corner, lidar_sensor.get_transform())

--- a/opencda/core/sensing/perception/obstacle_vehicle.py
+++ b/opencda/core/sensing/perception/obstacle_vehicle.py
@@ -20,7 +20,7 @@ def is_vehicle_cococlass(label):
     Check whether the label belongs to the vehicle class
     according to coco dataset.
     Args:
-        -label(int): The lable of the detecting object.
+        -label(int): The label of the detecting object.
 
     Returns:
         -is_vehicle(bool): Whether this label belongs to the vehicle class

--- a/opencda/core/sensing/perception/perception_manager.py
+++ b/opencda/core/sensing/perception/perception_manager.py
@@ -274,7 +274,7 @@ class SemanticLidarSensor:
 
 class PerceptionManager:
     """
-    Default perception module. Currenly only used to detect vehicles.
+    Default perception module. Currently only used to detect vehicles.
 
     Parameters
     ----------
@@ -664,7 +664,7 @@ class PerceptionManager:
                         abs(loc.y - obstacle_loc.y) <= 3.0:
                     obstacle_vehicle.set_velocity(v.get_velocity())
 
-                    # the case where the obstacle vehicle is controled by
+                    # the case where the obstacle vehicle is controlled by
                     # sumo
                     if self.cav_world.sumo2carla_ids:
                         sumo_speed = \

--- a/opencda/customize/core/sensing/localization/extented_kalman_filter.py
+++ b/opencda/customize/core/sensing/localization/extented_kalman_filter.py
@@ -117,7 +117,7 @@ class ExtentedKalmanFilter(object):
 
     def run_step_init(self, x, y, heading, velocity):
         """
-        Initalization for states.
+        Initialization for states.
 
         Args:
             -x (float): The X coordinate.

--- a/opencda/scenario_testing/utils/cosim_api.py
+++ b/opencda/scenario_testing/utils/cosim_api.py
@@ -245,7 +245,7 @@ class CoScenarioManager(ScenarioManager):
         """
         Accessor for traffic light state.
 
-        If the traffic ligth does not exist, returns None.
+        If the traffic light does not exist, returns None.
         """
         if landmark_id not in self._tls:
             return None

--- a/opencda/scenario_testing/utils/customized_map_api.py
+++ b/opencda/scenario_testing/utils/customized_map_api.py
@@ -37,7 +37,7 @@ def load_customized_world(xodr_path, client):
             try:
                 data = od_file.read()
             except OSError:
-                print('file could not be readed.')
+                print('file could not be read.')
                 sys.exit()
         print('load opendrive map %r.' % os.path.basename(xodr_path))
         vertex_distance = 2.0  # in meters

--- a/opencda/scenario_testing/utils/sim_api.py
+++ b/opencda/scenario_testing/utils/sim_api.py
@@ -62,7 +62,7 @@ def car_blueprint_filter(blueprint_library):
 
 class ScenarioManager:
     """
-    The manager that controls simulation construction, backgound traffic
+    The manager that controls simulation construction, background traffic
     generation and CAVs spawning.
 
     Parameters

--- a/setup.sh
+++ b/setup.sh
@@ -33,4 +33,4 @@ echo "Successful! Run 'pip install -e ${CACHE}/carla-0.9.11-py3.7-linux-x86_64' 
 conda activate opencda
 pip install -e ${CACHE}/carla-0.9.11-py3.7-linux-x86_64
 
-echo "Sucessful Setup!"
+echo "Successful Setup!"

--- a/test/test_ekf.py
+++ b/test/test_ekf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Unit test for Extented Kalman Filter.
+Unit test for Extended Kalman Filter.
 """
 # Author: Runsheng Xu <rxx3386@ucla.edu>
 # License: MIT


### PR DESCRIPTION
Fixes #109 via `codespell --ignore-words-list="nd,te" -w`