### PR TITLE
Travis CI: Test on the current versions of Ubuntu and Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
-dist: bionic
+dist: focal
 
 python:
   - "3.7"
-  - "3.8"
+  - "3.9"
 
 install:
   - pip install --upgrade pip


### PR DESCRIPTION
Python 3.10 release candidate 1 should be released next week so perhaps it is time to start testing on current Python.

If tests pass on both Python 3.7 and 3.9, it is almost certain they will also pass on 3.8.