### PR TITLE
torch version change for ci testing

### DIFF
--- a/requirements_ci.txt
+++ b/requirements_ci.txt
@@ -12,6 +12,6 @@ scikit-learn==0.24.2
 scipy==1.6.3
 seaborn
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.0+cpu
-torchvision==0.10.0+cpu
+torch==1.8.0+cpu
+torchvision==0.9.0+cpu
 tqdm>=4.41.0


### PR DESCRIPTION
Pytorch 1.9.0 with hub.load may cause http exceed limit error on CI, so switch to 1.8.0 on the CI testing