### PR TITLE
Feature/stop sign behavior

### DIFF
--- a/opencda/core/plan/behavior_agent.py
+++ b/opencda/core/plan/behavior_agent.py
@@ -382,10 +382,12 @@ class BehaviorAgent(object):
                 # stop sign
                 if self.stop_sign_wait_count < 60:
                     self.stop_sign_wait_count += 1
+                    # indicate emergent stop needed
                     return 1
                 # After pass a stop sign, the vehicle shouldn't stop at
                 # the stop sign in the opposite direction
                 else:
+                    # indicate no need to stop
                     return 0
 
 


### PR DESCRIPTION
In CARLA, the stop sign is always regarded as permanent red traffic light, thus the origin behavior will make the vehicle stops there forever. In this branch, I added a simple algorithm to solve this issue.