### PR TITLE
Sumo_cosim_debug

### DIFF
--- a/opencda/co_simulation/sumo_integration/sumo_simulation.py
+++ b/opencda/co_simulation/sumo_integration/sumo_simulation.py
@@ -301,7 +301,7 @@ def _get_sumo_net(cfg_file):
     net_file = os.path.join(os.path.dirname(cfg_file), tag.get('value'))
     logging.debug('Reading net file: %s', net_file)
 
-    sumo_net = traci.sumolib.net.readNet(net_file)
+    sumo_net = sumolib.net.readNet(net_file)
     return sumo_net
 
 class SumoSimulation(object):


### PR DESCRIPTION
Pull request information
Status: ready to merge
Kind of changes: bug fix

Description
I find a bug when I run  “opencda.py -t single_town06_cosim  -v 0.9.12 --apply_ml”. Specifically, in line 304 of file opencda\co_simulation\sumo_integration\sumo_simulation.py, traci.sumlib.net.readNet(net_file) is not supported. Instead, it should be sumlib.net.readNet(net_file).