### PR TITLE
[UCDavis] Add the OpenScenario module for unified autonomouos driving test

### DIFF
--- a/opencda/core/common/cav_world.py
+++ b/opencda/core/common/cav_world.py
@@ -55,6 +55,12 @@ class CavWorld(object):
         # this is used only when co-simulation activated.
         self.sumo2carla_ids = {}
 
+    def destroy(self):
+        for vehicle_manager in self._vehicle_manager_dict.values():
+            vehicle_manager.destroy()
+        for rsu_manager in self._rsu_manager_dict.values():
+            rsu_manager.destory()
+
     def update_vehicle_manager(self, vehicle_manager):
         """
         Update created CAV manager to the world.

--- a/opencda/core/map/map_manager.py
+++ b/opencda/core/map/map_manager.py
@@ -289,7 +289,10 @@ class MapManager(object):
             while nxt.road_id == waypoint.road_id \
                     and nxt.lane_id == waypoint.lane_id:
                 waypoints.append(nxt)
-                nxt = nxt.next(self.lane_sample_resolution)[0]
+                nxt_list = nxt.next(self.lane_sample_resolution)
+                if len(nxt_list) == 0:
+                    break
+                nxt = nxt_list[0]
 
             # waypoint is the centerline, we need to calculate left lane mark
             left_marking = [lateral_shift(w.transform, -w.lane_width * 0.5) for

--- a/opencda/scenario_testing/config_yaml/openscenario_carla.yaml
+++ b/opencda/scenario_testing/config_yaml/openscenario_carla.yaml
@@ -18,7 +18,7 @@ scenario_runner:
 
   configFile: './opencda/scenario_testing/scenarios/Overtake.xml'
   # Absolute path needed here
-  additionalScenario: '/home/ucdavis/opencda/scenario_testing/scenarios/overtake.py'
+  additionalScenario: '/home/ucdavis/OpenCDA/opencda/scenario_testing/scenarios/overtake.py'
 
   host: *host
   port: *port

--- a/opencda/scenario_testing/config_yaml/openscenario_carla.yaml
+++ b/opencda/scenario_testing/config_yaml/openscenario_carla.yaml
@@ -1,0 +1,41 @@
+description: |-
+  Author: Wei Shao <phdweishao@gmail.com>
+  Content: Test configurations for `openscenario_carla` that incorporates ScenarioRunner
+
+# Carla server settings
+
+world:
+  sync_mode: true
+  client_host: &host localhost
+  client_port: &port 2000
+
+# Scenario to test
+scenario:
+  host: *host
+  port: *port
+  timeout: 10
+  town: town01
+  # Use the configuration name from ScenarioRunner
+  scenario: FollowLeadingVehicle_1
+  debug: false
+  sync: false
+  repetitions: 1
+  agent: null
+  openscenario: null
+  route: null
+  configFile: ''
+  reloadWorld: false
+  waitForEgo: false
+  trafficManagerPort: '8000'
+  trafficManagerSeed: '0'
+  record: ''
+  additionalScenario: ''
+  agentConfig: ''
+  file: false
+  json: false
+  junit: false
+  list: false
+  penscenarioparams: null
+  output: false
+  outputDir: ''
+  randomize: false

--- a/opencda/scenario_testing/config_yaml/openscenario_carla.yaml
+++ b/opencda/scenario_testing/config_yaml/openscenario_carla.yaml
@@ -9,27 +9,31 @@ world:
   client_host: &host localhost
   client_port: &port 2000
 
-# Scenario to test
-scenario:
+# Parameters needed for ScenarioRunner
+scenario_runner:
+  town: town06
+  scenario: Overtake_1
+  # Number of actors to load in, including ego and other actors
+  num_actors: 5
+
+  configFile: './opencda/scenario_testing/scenarios/Overtake.xml'
+  # Absolute path needed here
+  additionalScenario: '/home/ucdavis/opencda/scenario_testing/scenarios/overtake.py'
+
   host: *host
   port: *port
   timeout: 10
-  town: town01
-  # Use the configuration name from ScenarioRunner
-  scenario: FollowLeadingVehicle_1
   debug: false
   sync: false
   repetitions: 1
   agent: null
   openscenario: null
   route: null
-  configFile: ''
   reloadWorld: false
   waitForEgo: false
   trafficManagerPort: '8000'
   trafficManagerSeed: '0'
   record: ''
-  additionalScenario: ''
   agentConfig: ''
   file: false
   json: false
@@ -39,3 +43,15 @@ scenario:
   output: false
   outputDir: ''
   randomize: false
+
+# Define OpenCDA scenario
+scenario:
+  single_cav_list:
+    - name: cav1
+      destination: [300, -17.2, 0.5]
+      v2x:
+        enabled: false
+      behavior:
+        local_planner:
+          debug_trajectory: false
+          debug: false

--- a/opencda/scenario_testing/openscenario_carla.py
+++ b/opencda/scenario_testing/openscenario_carla.py
@@ -7,7 +7,6 @@ from opencda.core.common.cav_world import CavWorld
 
 import time
 from multiprocessing import Process
-import psutil
 
 import scenario_runner as sr
 

--- a/opencda/scenario_testing/openscenario_carla.py
+++ b/opencda/scenario_testing/openscenario_carla.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+# License: TDG-Attribution-NonCommercial-NoDistrib
+
+import math
+import carla
+import opencda.scenario_testing.utils.sim_api as sim_api
+from opencda.core.common.cav_world import CavWorld
+
+import time
+from multiprocessing import Process
+
+import scenario_runner as sr
+
+def exec_scenario_runner(scenario_params):
+    """
+    Execute the SenarioRunner process
+
+    Parameters
+    ----------
+    scenario_params: Parameters of ScenarioRunner
+
+    Returns
+    -------
+    """
+    scenario_runner = sr.ScenarioRunner(scenario_params.scenario)
+    scenario_runner.run()
+    scenario_runner.destroy()
+
+
+def exec_ego_vehicle_runner(scenario_params):
+    """
+    Execute the ego vehicle runner
+
+    Parameters
+    ----------
+    scenario_params: Parameters of ScenarioRunner
+
+    Returns
+    -------
+    """
+    scenario_runner = None
+    cav_world = None
+    scenario_manager = None
+    client = None
+
+    try:
+        client_host = scenario_params.world.client_host
+        client_port = scenario_params.world.client_port
+        client = carla.Client(client_host, client_port)
+        world = client.get_world()
+
+        player = None
+        leading = None
+
+        while player is None:
+            print("Waiting for the ego vehicle...")
+            time.sleep(2)
+            possible_vehicles = world.get_actors().filter('vehicle.*')
+            for vehicle in possible_vehicles:
+                if vehicle.attributes['role_name'] == 'hero':
+                    print("Ego vehicle found")
+                    player = vehicle
+                if vehicle.attributes['role_name'] == 'scenario':
+                    print("Leading vehicle found")
+                    leading = vehicle
+                
+        spectator = player.get_world().get_spectator()
+        # Bird view following
+        spectator_altitude = 80
+        spectator_bird_pitch = -90
+        
+        while True:
+            world.tick()
+            
+            # Get the control of the ego vehicle
+            control = leading.get_control()
+            # Get the distance between the ego and leading vehicles
+            distance = leading.get_location().distance(player.get_location())
+            # Get the velocity of the ego vehicle on the x-y plane
+            ego_velocity = math.sqrt(player.get_velocity().x ** 2 + player.get_velocity().y ** 2)
+            leading_velocity = math.sqrt(leading.get_velocity().x ** 2 + leading.get_velocity().y ** 2)
+            
+            # Wait for the leading vehicle to start
+            if leading_velocity < 0.1: 
+                control = carla.VehicleControl(throttle=0.50000, steer=0, brake=0.000000, hand_brake=False,
+                                            reverse=False, manual_gear_shift=False, gear=0)
+            # If the leading vehicle is too close, stop the ego vehicle
+            elif distance < 1.7 * ego_velocity or distance < 10:
+                control = carla.VehicleControl(throttle=0, steer=0, brake=1.0, hand_brake=True,
+                                            reverse=False, manual_gear_shift=False, gear=0)
+            
+            print("Distance: {}, Ego velocity: {}, Leading velocity: {}".format(distance, ego_velocity, leading_velocity))
+            # Bird view following
+            view_transform = carla.Transform()
+            view_transform.location = player.get_transform().location
+            view_transform.location.z = view_transform.location.z + spectator_altitude
+            view_transform.rotation.pitch = spectator_bird_pitch
+            spectator.set_transform(view_transform)
+
+            # Apply the control to the ego vehicle
+            player.apply_control(control)
+            time.sleep(0.05)
+    finally:
+        if cav_world is not None:
+            cav_world.destroy()
+        print("Destroyed cav_world")
+        if scenario_manager is not None:
+            scenario_manager.destroyActors()
+            scenario_manager.close()
+        if scenario_runner is not None:
+            scenario_runner.destroy()
+            del scenario_runner
+        print("Destroyed scenario_runner...")
+
+
+def run_scenario(opt, scenario_params):
+    try:
+        # Create CAV world
+        cav_world = CavWorld(opt.apply_ml)
+        # Create scenario manager
+        sim_api.ScenarioManager(scenario_params,
+                                opt.apply_ml,
+                                opt.version,
+                                town=scenario_params.scenario.town,
+                                cav_world=cav_world)
+
+        # Create a background process to init and execute scenario runner
+        sr_process = Process(target=exec_scenario_runner, args=(scenario_params, ))
+        # Create a parallel process to init and run EI-Drive
+        ei_process = Process(target=exec_ego_vehicle_runner, args=(scenario_params, ))
+
+        sr_process.start()
+        ei_process.start()
+        
+        sr_process.join()
+        ei_process.join()
+        
+
+
+    except Exception as e:
+        print("Error: {}".format(e))

--- a/opencda/scenario_testing/openscenario_carla.py
+++ b/opencda/scenario_testing/openscenario_carla.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 # License: TDG-Attribution-NonCommercial-NoDistrib
 
-import math
 import carla
 import opencda.scenario_testing.utils.sim_api as sim_api
 from opencda.core.common.cav_world import CavWorld
 
 import time
 from multiprocessing import Process
+import psutil
 
 import scenario_runner as sr
+
 
 def exec_scenario_runner(scenario_params):
     """
@@ -22,120 +23,81 @@ def exec_scenario_runner(scenario_params):
     Returns
     -------
     """
-    scenario_runner = sr.ScenarioRunner(scenario_params.scenario)
+    scenario_runner = sr.ScenarioRunner(scenario_params.scenario_runner)
     scenario_runner.run()
     scenario_runner.destroy()
 
 
-def exec_ego_vehicle_runner(scenario_params):
-    """
-    Execute the ego vehicle runner
-
-    Parameters
-    ----------
-    scenario_params: Parameters of ScenarioRunner
-
-    Returns
-    -------
-    """
+def run_scenario(opt, scenario_params):
     scenario_runner = None
     cav_world = None
     scenario_manager = None
-    client = None
 
     try:
-        client_host = scenario_params.world.client_host
-        client_port = scenario_params.world.client_port
-        client = carla.Client(client_host, client_port)
-        world = client.get_world()
+        # Create CAV world
+        cav_world = CavWorld(opt.apply_ml)
+        # Create scenario manager
+        scenario_manager = sim_api.ScenarioManager(scenario_params,
+                                                   opt.apply_ml,
+                                                   opt.version,
+                                                   town=scenario_params.scenario_runner.town,
+                                                   cav_world=cav_world)
 
-        player = None
-        leading = None
+        # Create a background process to init and execute scenario runner
+        sr_process = Process(target=exec_scenario_runner,
+                             args=(scenario_params, ))
+        sr_process.start()
+        
+        world = scenario_manager.world
+        ego_vehicle = None
+        num_actors = 0
 
-        while player is None:
-            print("Waiting for the ego vehicle...")
+        while ego_vehicle is None or num_actors < scenario_params.scenario_runner.num_actors:
+            print("Waiting for the actors")
             time.sleep(2)
-            possible_vehicles = world.get_actors().filter('vehicle.*')
-            for vehicle in possible_vehicles:
+            vehicles = world.get_actors().filter('vehicle.*')
+            walkers = world.get_actors().filter('walker.*')
+            for vehicle in vehicles:
                 if vehicle.attributes['role_name'] == 'hero':
                     print("Ego vehicle found")
-                    player = vehicle
-                if vehicle.attributes['role_name'] == 'scenario':
-                    print("Leading vehicle found")
-                    leading = vehicle
-                
-        spectator = player.get_world().get_spectator()
+                    ego_vehicle = vehicle
+            num_actors = len(vehicles) + len(walkers)
+        print(f'Found all {num_actors} actors')
+
+        single_cav_list = scenario_manager.create_vehicle_manager_from_scenario_runner(
+            vehicle=ego_vehicle,
+        )
+
+        spectator = ego_vehicle.get_world().get_spectator()
         # Bird view following
-        spectator_altitude = 80
+        spectator_altitude = 50
         spectator_bird_pitch = -90
-        
+
         while True:
-            world.tick()
-            
-            # Get the control of the ego vehicle
-            control = leading.get_control()
-            # Get the distance between the ego and leading vehicles
-            distance = leading.get_location().distance(player.get_location())
-            # Get the velocity of the ego vehicle on the x-y plane
-            ego_velocity = math.sqrt(player.get_velocity().x ** 2 + player.get_velocity().y ** 2)
-            leading_velocity = math.sqrt(leading.get_velocity().x ** 2 + leading.get_velocity().y ** 2)
-            
-            # Wait for the leading vehicle to start
-            if leading_velocity < 0.1: 
-                control = carla.VehicleControl(throttle=0.50000, steer=0, brake=0.000000, hand_brake=False,
-                                            reverse=False, manual_gear_shift=False, gear=0)
-            # If the leading vehicle is too close, stop the ego vehicle
-            elif distance < 1.7 * ego_velocity or distance < 10:
-                control = carla.VehicleControl(throttle=0, steer=0, brake=1.0, hand_brake=True,
-                                            reverse=False, manual_gear_shift=False, gear=0)
-            
-            print("Distance: {}, Ego velocity: {}, Leading velocity: {}".format(distance, ego_velocity, leading_velocity))
+            scenario_manager.tick()
+            ego_cav = single_cav_list[0].vehicle
+
             # Bird view following
             view_transform = carla.Transform()
-            view_transform.location = player.get_transform().location
+            view_transform.location = ego_cav.get_transform().location
             view_transform.location.z = view_transform.location.z + spectator_altitude
             view_transform.rotation.pitch = spectator_bird_pitch
             spectator.set_transform(view_transform)
 
             # Apply the control to the ego vehicle
-            player.apply_control(control)
-            time.sleep(0.05)
+            for _, single_cav in enumerate(single_cav_list):
+                single_cav.update_info()
+                control = single_cav.run_step()
+                single_cav.vehicle.apply_control(control)
+            time.sleep(0.01)
+
     finally:
         if cav_world is not None:
             cav_world.destroy()
         print("Destroyed cav_world")
         if scenario_manager is not None:
-            scenario_manager.destroyActors()
             scenario_manager.close()
+        print("Destroyed scenario_manager")
         if scenario_runner is not None:
             scenario_runner.destroy()
-            del scenario_runner
-        print("Destroyed scenario_runner...")
-
-
-def run_scenario(opt, scenario_params):
-    try:
-        # Create CAV world
-        cav_world = CavWorld(opt.apply_ml)
-        # Create scenario manager
-        sim_api.ScenarioManager(scenario_params,
-                                opt.apply_ml,
-                                opt.version,
-                                town=scenario_params.scenario.town,
-                                cav_world=cav_world)
-
-        # Create a background process to init and execute scenario runner
-        sr_process = Process(target=exec_scenario_runner, args=(scenario_params, ))
-        # Create a parallel process to init and run EI-Drive
-        ei_process = Process(target=exec_ego_vehicle_runner, args=(scenario_params, ))
-
-        sr_process.start()
-        ei_process.start()
-        
-        sr_process.join()
-        ei_process.join()
-        
-
-
-    except Exception as e:
-        print("Error: {}".format(e))
+        print("Destroyed scenario_runner")

--- a/opencda/scenario_testing/scenarios/Overtake.xml
+++ b/opencda/scenario_testing/scenarios/Overtake.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<scenarios>
+    <scenario name="Overtake_1" type="Overtake" town="Town06">
+        <ego_vehicle x="490" y="-17.1" z="0.3" yaw="180" model="vehicle.nissan.patrol" />
+        <other_actor x="450" y="-17.1" z="-500" yaw="180" model="vehicle.tesla.model3" />
+        <other_actor x="440" y="-20.2" z="-500" yaw="180" model="vehicle.nissan.seat.leon" />
+        <other_actor x="380" y="-15" z="-500" yaw="180" model="walker.pedestrian.0001" />
+        <other_actor x="380" y="-19" z="-500" yaw="180" model="walker.pedestrian.0002" />
+        <weather cloudiness="0" precipitation="0" precipitation_deposits="0" wind_intensity="0" sun_azimuth_angle="0" sun_altitude_angle="75" />
+    </scenario>
+</scenarios>

--- a/opencda/scenario_testing/scenarios/overtake.py
+++ b/opencda/scenario_testing/scenarios/overtake.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+
+"""
+Overtake Scenario:
+
+This is demo module showing integration of OpenCDA with ScenarioRunner.
+
+The scripts simulate a scenario where an ego vehicle has to overtake a background vehicle
+that is ahead of the ego vehicle and at a lower speed. There are two fearless pedestrians
+that suddenly appear in front of the ego vehicle and the ego vehicle has to avoid a collision
+"""
+
+import py_trees
+import carla
+
+from srunner.scenariomanager.carla_data_provider import CarlaDataProvider
+from srunner.scenariomanager.scenarioatomics.atomic_behaviors import (ActorTransformSetter,
+                                                                      WaypointFollower,
+                                                                      Idle)
+from srunner.scenariomanager.scenarioatomics.atomic_criteria import CollisionTest
+from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import DriveDistance, InTriggerDistanceToLocation
+from srunner.scenarios.basic_scenario import BasicScenario
+
+
+class Overtake(BasicScenario):
+
+    """
+    The class spawns two background vehicles and two pedestrians in front of the ego vehicle.
+    The ego vehicle is driving behind and overtaking the fast vehicle ahead
+
+    self.other_actors[0] = fast car
+    self.other_actors[1] = slow car
+    self.other_actors[2] = pedestrian 1
+    self.other_actors[3] = pedestrian 2
+    """
+
+    timeout = 1200
+
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
+                 timeout=600):
+        """
+        Setup all relevant parameters and create scenario
+        """
+        print("Running Overtake Scenario")
+        self.timeout = timeout
+        self._map = CarlaDataProvider.get_map()
+        self._reference_waypoint = self._map.get_waypoint(
+            config.trigger_points[0].location)
+
+        self._fast_vehicle_velocity = 30
+        self._slow_vehicle_velocity = 20
+        self._pedestrian_velocity = 5
+        self._trigger_distance = 35
+
+        super(Overtake, self).__init__("Overtake",
+                                       ego_vehicles,
+                                       config,
+                                       world,
+                                       debug_mode,
+                                       criteria_enable=criteria_enable)
+
+    def _initialize_actors(self, config):
+        # Spawn leading vehicles and the fearless pedestrian
+        for actor_config in config.other_actors:
+            actor = CarlaDataProvider.request_new_actor(
+                actor_config.model, actor_config.transform)
+            self.other_actors.append(actor)
+            actor.set_simulate_physics(enabled=False)
+
+        # Transformation that renders the fast vehicle visible
+        fast_car_transform = self.other_actors[0].get_transform()
+        self.fast_car_visible = carla.Transform(
+            carla.Location(fast_car_transform.location.x,
+                           fast_car_transform.location.y,
+                           fast_car_transform.location.z + 501),
+            fast_car_transform.rotation)
+        # Transformation that renders the slow vehicle visible
+        slow_car_transform = self.other_actors[1].get_transform()
+        self.slow_car_visible = carla.Transform(
+            carla.Location(slow_car_transform.location.x,
+                           slow_car_transform.location.y,
+                           slow_car_transform.location.z + 501),
+            slow_car_transform.rotation)
+
+        # Transformation that renders the pedestrian visible
+        pedestrian_transform_1 = self.other_actors[2].get_transform()
+        self.pedestrian_visible_1 = carla.Transform(
+            carla.Location(pedestrian_transform_1.location.x,
+                           pedestrian_transform_1.location.y,
+                           pedestrian_transform_1.location.z + 501),
+            pedestrian_transform_1.rotation)
+        pedestrian_transform_2 = self.other_actors[3].get_transform()
+        self.pedestrian_visible_2 = carla.Transform(
+            carla.Location(pedestrian_transform_2.location.x,
+                           pedestrian_transform_2.location.y,
+                           pedestrian_transform_2.location.z + 501),
+            pedestrian_transform_2.rotation)
+
+        # Trigger location for the actors
+        self.fast_vehicle_trigger_location = carla.Location(
+            fast_car_transform.location.x,
+            fast_car_transform.location.y,
+            fast_car_transform.location.z + 501,
+        )
+        self.slow_vehicle_trigger_location = carla.Location(
+            slow_car_transform.location.x,
+            slow_car_transform.location.y,
+            slow_car_transform.location.z + 501,
+        )
+        self.pedestrian_trigger_location = carla.Location(
+            (pedestrian_transform_1.location.x +
+             pedestrian_transform_2.location.x) / 2,
+            pedestrian_transform_1.location.y,
+            pedestrian_transform_1.location.z + 501,
+        )
+
+        self._pedestrian_target_1 = carla.Location(
+            carla.Location(pedestrian_transform_2.location.x - 15,
+                           pedestrian_transform_2.location.y,
+                           pedestrian_transform_2.location.z + 501)
+        )
+        self._pedestrian_target_2 = carla.Location(
+            carla.Location(pedestrian_transform_1.location.x - 15,
+                           pedestrian_transform_1.location.y,
+                           pedestrian_transform_1.location.z + 501)
+        )
+
+    def _create_behavior(self):
+        # Slow vehicle behaviors
+        sequence_slow_vehicle = py_trees.composites.Sequence("Slow Vehicle")
+        trigger_slow_vehicle = InTriggerDistanceToLocation(
+            self.ego_vehicles[0], self.slow_vehicle_trigger_location, self._trigger_distance)
+        set_slow_visible = ActorTransformSetter(
+            self.other_actors[1], self.slow_car_visible)
+        slow_vehicle_drive = WaypointFollower(
+            self.other_actors[1], self._slow_vehicle_velocity)
+        sequence_slow_vehicle.add_child(set_slow_visible)
+        sequence_slow_vehicle.add_child(trigger_slow_vehicle)
+        sequence_slow_vehicle.add_child(slow_vehicle_drive)
+        sequence_slow_vehicle.add_child(Idle())
+
+        # Fast vehicle behaviors
+        sequence_fast_vehicle = py_trees.composites.Sequence("Fast Vehicle")
+        trigger_fast_vehicle = InTriggerDistanceToLocation(
+            self.ego_vehicles[0], self.fast_vehicle_trigger_location, self._trigger_distance)
+        set_fast_visible = ActorTransformSetter(
+            self.other_actors[0], self.fast_car_visible)
+        fast_vehicle_drive = WaypointFollower(
+            self.other_actors[0], self._fast_vehicle_velocity)
+        # Drive fast vehicle
+        sequence_fast_vehicle.add_child(set_fast_visible)
+        sequence_fast_vehicle.add_child(trigger_fast_vehicle)
+        sequence_fast_vehicle.add_child(fast_vehicle_drive)
+        sequence_fast_vehicle.add_child(Idle())
+
+        # Pedestrian behaviors
+        sequence_pedestrians = py_trees.composites.Sequence(
+            "Pedestrians", policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)
+        trigger_slow_vehicle = InTriggerDistanceToLocation(
+            self.ego_vehicles[0], self.pedestrian_trigger_location, 15)
+        # Pedestrian 1 behaviors
+        sequence_pedestrian_1 = py_trees.composites.Sequence("Pedestrian 1")
+        set_pedestrian_visible_1 = ActorTransformSetter(
+            self.other_actors[2], self.pedestrian_visible_1)
+        walk_1 = WaypointFollower(
+            self.other_actors[2], self._pedestrian_velocity, [self._pedestrian_target_1])
+        sequence_pedestrian_1.add_child(set_pedestrian_visible_1)
+        sequence_pedestrian_1.add_child(trigger_slow_vehicle)
+        sequence_pedestrian_1.add_child(walk_1)
+
+        # Pedestrian 2 behaviors
+        sequence_pedestrian_2 = py_trees.composites.Sequence("Pedestrian 2")
+        set_pedestrian_visible_2 = ActorTransformSetter(
+            self.other_actors[3], self.pedestrian_visible_2)
+        walk_2 = WaypointFollower(
+            self.other_actors[3], self._pedestrian_velocity, [self._pedestrian_target_2])
+        sequence_pedestrian_2.add_child(set_pedestrian_visible_2)
+        sequence_pedestrian_2.add_child(trigger_slow_vehicle)
+        sequence_pedestrian_2.add_child(walk_2)
+
+        pedestrians_move = py_trees.composites.Parallel(
+            "Pedestrians Move", policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)
+        pedestrians_move.add_child(sequence_pedestrian_1)
+        pedestrians_move.add_child(sequence_pedestrian_2)
+        sequence_pedestrians.add_child(pedestrians_move)
+
+        # End condition
+        termination = DriveDistance(self.ego_vehicles[0], 250)
+
+        # Build composite behavior tree
+        root = py_trees.composites.Parallel(
+            "Parallel Behavior", policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)
+        root.add_child(sequence_slow_vehicle)
+        root.add_child(sequence_fast_vehicle)
+        root.add_child(sequence_pedestrians)
+        root.add_child(termination)
+        return root
+
+    def _create_test_criteria(self):
+        """
+        A list of all test criteria will be created that is later used
+        in parallel behavior tree.
+        """
+        criteria = []
+
+        collision_criterion = CollisionTest(self.ego_vehicles[0])
+
+        criteria.append(collision_criterion)
+
+        return criteria
+
+    def __del__(self):
+        """
+        Remove all actors upon deletion
+        """
+        self.remove_all_actors()


### PR DESCRIPTION
The commit adds a new module for `OpenCDA` that supports running unified autonomouos driving test with custom autonomous driving algorithms and pre-defined scenarios.

Specifically, the program involves two pipeline executed concurrently: an ego vehicle algorithm runner where autonomous driving algorithms are adopted, and a ScenarioRunner pipeline that tests against preset scenarios.

To test the new module:

```bash
python opencda.py -t openscenario_carla -v 0.9.14
```

### Changes

- `openscenario_carla`: Config scripts that pull up two subprocesses including a ScenarioRunner subprocess and a ego vehicle controlling subprocess.
- `openscenario_carla.yaml`: YAML configurations.

### Prerequisites

- We need to first install SenarioRunner: [SenarioRunner documents](https://carla-scenariorunner.readthedocs.io/en/latest/).

- Insert `SenarioRunner` to the Python API paths so that it can be imported. `SenarioRunner` locates resource paths with `SENARIO_RUNNER_ROOT`.

Therefore, we can execute the following commands to set up ScenarioRunner environmental variables:

```bash
export SCENARIO_RUNNER_ROOT="/to/scenario_runner/installation/path"   # Change to your own installation path
export PYTHONPATH="$SCENARIO_RUNNER_ROOT:$PYTHONPATH"        # Add to Python API path to import
```

- Create an empty `__init__.py` under the `SenarioRunner` installation folder, so that the folder is treated as a package. You can create the file manually or use the command:

```bash
touch "$SCENARIO_RUNNER_ROOT/__init__.py"
```