### PR TITLE
Add omegaconf as one of the imported packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ scipy==1.6.3
 seaborn
 lxml
 shapely==1.8.4
+omegaconf


### PR DESCRIPTION
```
opencda-latest) ztu@lambda-quad:~/OpenCDA$ python opencda.py -t openscenario_carla -v 0.9.14
Traceback (most recent call last):
  File "opencda.py", line 13, in <module>
    from omegaconf import OmegaConf
ModuleNotFoundError: No module named 'omegaconf'
```